### PR TITLE
Fixes für Telemetrie-Config/DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ poll_interval_minutes = 180
 request_timeout = 60
 max_retries = 3
 default_path_mode = flood
-database_path = telemetry_data.db
+database_path = /data/databases/telemetry_data.db
 # MQTT aktivieren für externe Systeme
 mqtt_enabled = true
 mqtt_topic_request = meshcore/telemetry/request

--- a/config.hbmesh.ini
+++ b/config.hbmesh.ini
@@ -549,7 +549,7 @@ max_retries = 3
 # Path mode: flood, direct, or custom hex (e.g. 01,5f)
 default_path_mode = flood
 # Database file for telemetry data
-database_path = telemetry_data.db
+database_path = /data/databases/telemetry_data.db
 # MQTT for remote telemetry requests/responses
 # Broker-Verbindung kommt aus [MQTT] Sektion
 mqtt_enabled = true

--- a/modules/web_viewer/app.py
+++ b/modules/web_viewer/app.py
@@ -2547,7 +2547,7 @@ class BotDataViewer:
                 return jsonify({'error': str(e)}), 500
         
         # Initialize Services API module (HBME Ingestor, etc.)
-        self.services_api = ServicesAPI(self.app, self.db_manager, self.logger)
+        self.services_api = ServicesAPI(self.app, self.db_manager, self.logger, self.config)
     
     def _setup_socketio_handlers(self):
         """Setup SocketIO event handlers using modern patterns"""

--- a/modules/web_viewer/app.py
+++ b/modules/web_viewer/app.py
@@ -11,9 +11,9 @@ import configparser
 import logging
 import subprocess
 import threading
-from datetime import datetime, timedelta, date
+from datetime import datetime
 from flask import Flask, render_template, jsonify, request, send_from_directory, make_response
-from flask_socketio import SocketIO, emit, join_room, leave_room, disconnect
+from flask_socketio import SocketIO, emit, disconnect
 from pathlib import Path
 import os
 import sys
@@ -23,7 +23,6 @@ from typing import Dict, Any, Optional, List
 project_root = os.path.join(os.path.dirname(__file__), '..', '..')
 sys.path.insert(0, project_root)
 
-from modules.db_manager import DBManager
 from modules.repeater_manager import RepeaterManager
 from modules.utils import resolve_path, calculate_distance
 from modules.web_viewer.services_api import ServicesAPI

--- a/modules/web_viewer/services_api.py
+++ b/modules/web_viewer/services_api.py
@@ -16,7 +16,7 @@ from flask import jsonify, request
 class ServicesAPI:
     """Handles Services API endpoints for external integrations."""
     
-    def __init__(self, app, db_manager, logger, bot_instance=None):
+    def __init__(self, app, db_manager, logger, config=None, bot_instance=None):
         """Initialize Services API.
         
         Args:
@@ -28,6 +28,7 @@ class ServicesAPI:
         self.app = app
         self.db_manager = db_manager
         self.logger = logger
+        self.config = config
         self.bot = bot_instance
         self._register_routes()
     

--- a/modules/web_viewer/services_api.py
+++ b/modules/web_viewer/services_api.py
@@ -5,6 +5,7 @@ Handles API endpoints for external service integrations (HBME Ingestor, Telemetr
 """
 
 import asyncio
+import functools
 import json
 import os
 import sqlite3
@@ -819,20 +820,11 @@ class ServicesAPI:
     # ─────────────────────────────────────────────────────────────────────────
     # Telemetry Monitor Methods
     # ─────────────────────────────────────────────────────────────────────────
-    
+
+    @functools.cache
     def _get_telemetry_db_path(self) -> str:
         """Resolve the telemetry database path from config."""
-        import configparser
-        config = configparser.ConfigParser()
-        # Get the config path from the app instance
-        config_path = getattr(self.app, '_config_path', None)
-        if not config_path:
-            # Fallback: resolve from bot root
-            bot_root = os.path.join(os.path.dirname(__file__), '..', '..')
-            config_path = os.path.join(bot_root, 'config.ini')
-        config.read(config_path, encoding='utf-8')
-        
-        db_path = config.get('TelemetryMonitor', 'database_path', fallback='telemetry_data.db')
+        db_path = self.config.get('TelemetryMonitor', 'database_path', fallback='telemetry_data.db')
         if not os.path.isabs(db_path):
             bot_root = os.path.join(os.path.dirname(__file__), '..', '..')
             db_path = os.path.join(os.path.abspath(bot_root), db_path)
@@ -844,31 +836,24 @@ class ServicesAPI:
         conn = sqlite3.connect(db_path, timeout=10.0)
         conn.row_factory = sqlite3.Row
         return conn
-    
+
+    @functools.cache
     def _get_telemetry_config(self) -> dict:
         """Read TelemetryMonitor config section."""
-        import configparser
-        config = configparser.ConfigParser()
-        config_path = getattr(self.app, '_config_path', None)
-        if not config_path:
-            bot_root = os.path.join(os.path.dirname(__file__), '..', '..')
-            config_path = os.path.join(bot_root, 'config.ini')
-        config.read(config_path, encoding='utf-8')
-        
-        if not config.has_section('TelemetryMonitor'):
+        if not self.config.has_section('TelemetryMonitor'):
             return {'enabled': False}
         
         return {
-            'enabled': config.getboolean('TelemetryMonitor', 'enabled', fallback=False),
-            'poll_interval_minutes': config.getint('TelemetryMonitor', 'poll_interval_minutes', fallback=30),
-            'request_timeout': config.getint('TelemetryMonitor', 'request_timeout', fallback=60),
-            'max_retries': config.getint('TelemetryMonitor', 'max_retries', fallback=3),
-            'default_path_mode': config.get('TelemetryMonitor', 'default_path_mode', fallback='flood'),
-            'mqtt_enabled': config.getboolean('TelemetryMonitor', 'mqtt_enabled', fallback=False),
-            'mqtt_server': config.get('MQTT', 'server', fallback='localhost'),
-            'mqtt_port': config.getint('MQTT', 'port', fallback=1883),
-            'mqtt_topic_request': config.get('TelemetryMonitor', 'mqtt_topic_request', fallback='meshcore/telemetry/request'),
-            'mqtt_topic_response': config.get('TelemetryMonitor', 'mqtt_topic_response', fallback='meshcore/telemetry/response'),
+            'enabled': self.config.getboolean('TelemetryMonitor', 'enabled', fallback=False),
+            'poll_interval_minutes': self.config.getint('TelemetryMonitor', 'poll_interval_minutes', fallback=30),
+            'request_timeout': self.config.getint('TelemetryMonitor', 'request_timeout', fallback=60),
+            'max_retries': self.config.getint('TelemetryMonitor', 'max_retries', fallback=3),
+            'default_path_mode': self.config.get('TelemetryMonitor', 'default_path_mode', fallback='flood'),
+            'mqtt_enabled': self.config.getboolean('TelemetryMonitor', 'mqtt_enabled', fallback=False),
+            'mqtt_server': self.config.get('MQTT', 'server', fallback='localhost'),
+            'mqtt_port': self.config.getint('MQTT', 'port', fallback=1883),
+            'mqtt_topic_request': self.config.get('TelemetryMonitor', 'mqtt_topic_request', fallback='meshcore/telemetry/request'),
+            'mqtt_topic_response': self.config.get('TelemetryMonitor', 'mqtt_topic_response', fallback='meshcore/telemetry/response'),
         }
     
     def _get_telemetry_status(self) -> dict:


### PR DESCRIPTION
Diese Commits beheben mehrere Konfigurations- und Telemetrie-Bugs:                                                                                                                                                                                                                                                     

- Der Default-Pfad in der `config.hbmesh.ini` und in der `README.md` für die Telemetrie-Datenbank wurde angepasst, damit die DB nicht innerhalb des Containers erstellt wird und bei einem Update/Neustart verloren geht. Das behebt den Bug, dass die Repeater nach einem Neustart immer wieder eingetragen werden müssen.
- Das automatische Finden der `config.ini` hat nicht funktioniert, so dass hauptsächlich mit den Defaultwerten im Telemetrie-Teil gearbeitet wurde. Die `config.ini` wird jetzt nicht mehr manuell gesucht, sondern es wird eine Instanz an die ServiceAPI übergeben.
- Die Ermittlung des Pfads für die Telemetrie-DB und sowie das Holen der Telemetrie-Config findet jetzt nur noch 1x statt und wird dann gecached.
- Unnötige Imports wurden entfernt.